### PR TITLE
Double fixes

### DIFF
--- a/src/unpack.cpp
+++ b/src/unpack.cpp
@@ -273,7 +273,14 @@ public:
 
     static const unsigned N = 100;
     char buf[N];
+
+#if __EMSCRIPTEN__
+    int len = emscripten_print_double(d, buf);
+    assert(len < N-1);
+    buf[len] = 0;
+#else
     uint32_t len = snprintf(buf, N, "%g", d);
+#endif
 
     check_write(len);
     memcpy(cur_, buf, len);

--- a/src/unpack.cpp
+++ b/src/unpack.cpp
@@ -246,15 +246,9 @@ public:
 
   void float32(double f)
   {
-    static const unsigned N = 100;
-    char buf[N];
-    uint32_t len = snprintf(buf, N, "%g", (double)f);
-
     name(HotStdLib::FRound);
     ascii('(');
-    check_write(len);
-    memcpy(cur_, buf, len);
-    cur_ += len;
+    float64((double)f);
     ascii(')');
   }
 


### PR DESCRIPTION
This uses a new emscripten API to properly print doubles with full precision - since JS engines have that ability, it just hands off the problem to them.

This does **not** solve the problem when running the unpacker natively. See #5 for discussion.