### PR TITLE
Handle negative zero

### DIFF
--- a/src/unpack.cpp
+++ b/src/unpack.cpp
@@ -264,7 +264,9 @@ public:
     if (std::isinf(d))
         return name(StdLib::Infinity);
 
-    if (d < 0) {
+    // handle negative numbers. to detect -0 (which has -0 == 0), we must
+    // inspect the sign bit.
+    if (d < 0 || (d == 0 && std::signbit((float)d) == 1)) {
       ascii('-');
       d = -d;
     }


### PR DESCRIPTION
Negative zero is a never-ending source of "fun". This fixes printing of them in the polyfill.

(Casting to a float is an optimization for emscripten; otherwise, to get the 64 bits of the double, it uses two 32-bit values and does some more pointless work.)