### PR TITLE
src: cashew: build.sh: Remove path to clang++

### DIFF
--- a/src/cashew/build.sh
+++ b/src/cashew/build.sh
@@ -1,2 +1,2 @@
-~/Dev/fastcomp/build/Release+Asserts/bin/clang++ -std=c++11 parser.cpp simple_ast.cpp test.cpp -g
+clang++ -std=c++11 parser.cpp simple_ast.cpp test.cpp -g
 


### PR DESCRIPTION
No need to keep all the clang++ path in the build file. clang++ should be installed separately (and not necessarily in that folder).

Signed-off-by: Valentin Ilie <valentin.ilie@intel.com>