### PR TITLE
Fix use of hasOwnProperty

### DIFF
--- a/jslib/load-wasm.js
+++ b/jslib/load-wasm.js
@@ -12,7 +12,7 @@ var loadWebAssembly = (function() {
       var callbackName = "";
       do {
         callbackName = "onFinishLoadWebAssembly_" + globalNameCounter++;
-      } while (Object.hasOwnProperty(window, callbackName));
+      } while (Object.prototype.hasOwnProperty.call(window, callbackName));
       window[callbackName] = function(asmModule) {
         delete window[callbackName];
         resolve(asmModule);


### PR DESCRIPTION
`Object.hasOwnProperty(obj, key)` is not a shortcut for `obj.hasOwnProperty(key)`. To see, `Object.hasOwnProperty({ x: true }, 'x')`.