### PR TITLE
Fix compilation with recent Emscripten

### DIFF
--- a/src/shared.h
+++ b/src/shared.h
@@ -363,7 +363,7 @@ inline ExprPOD::operator Expr () const {
   result.type_ = type_;
   result.u.raw_ = raw_code_;
   return result;
-};
+}
 
 static const uint8_t HasImmFlag = 0x80;
 static_assert(uint8_t(I32::Bad) <= HasImmFlag, "MSB reserved to distinguish I32 from I32WithImm");

--- a/src/unpack.cpp
+++ b/src/unpack.cpp
@@ -276,7 +276,7 @@ public:
     uint32_t len;
 
 #if __EMSCRIPTEN__
-    len = emscripten_print_double(d, buf);
+    len = emscripten_print_double(d, buf, N);
     assert(len < N-1);
     buf[len] = 0;
 #else


### PR DESCRIPTION
src/unpack.cpp:279:11: error: no matching function for call to 'emscripten_print_double'
    len = emscripten_print_double(d, buf);
          ^~~~~~~~~~~~~~~~~~~~~~~
/usr/src/emsdk_portable/emscripten/incoming/system/include/emscripten/emscripten.h:251:5: note: candidate function not viable: requires 3 arguments, but 2 were provided
int emscripten_print_double(double x, char *to, signed max);
    ^
1 error generated.
