### PR TITLE
Use __EMSCRIPTEN__ and not EMSCRIPTEN.

### DIFF
--- a/src/unpack.cpp
+++ b/src/unpack.cpp
@@ -10,7 +10,7 @@
 #include <cstdio>
 #include <cmath>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 # include <emscripten.h>
 #endif
 


### PR DESCRIPTION
We prefer to use **EMSCRIPTEN** as the preprocessor flag for detecting
emscripten.
